### PR TITLE
Support sccache and ccache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,19 @@
 # See docs/CMake.html for instructions about how to build LLVM with CMake.
-
 cmake_minimum_required(VERSION 3.4.3)
+
+find_program(SCCACHE_FOUND sccache)
+if (SCCACHE_FOUND)
+  message(STATUS "Using sccache")
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE sccache)
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK sccache)
+else()
+  find_program(CCACHE_FOUND ccache)
+  if (CCACHE_FOUND)
+    message(STATUS "Using ccache")
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+  endif()
+endif()
 
 cmake_policy(SET CMP0022 NEW)
 


### PR DESCRIPTION
This pull request modifies LLVM's CMake to automatically detect the presence of [sccache](https://github.com/mozilla/sccache) and use it to accelerate compiling and linking. If sccache is not found, CMake will look for [ccache](https://github.com/ccache/ccache) to use for compiling and linking. If neither sccache nor ccache are found on the host, behavior will be unchanged.

This change is necessary to implement sccache on the `eosio-dot-cdt` CI/CD pipeline, which will allow us to substantially reduce build times.

### Tested
I have tested these changes on my local machine which has the following environment...
```
llvm$ sw_vers
ProductName:	Mac OS X
ProductVersion:	10.14.5
BuildVersion:	18F132
llvm$ cmake --version
cmake version 3.14.1

CMake suite maintained and supported by Kitware (kitware.com/cmake).
llvm$ ls /usr/local/Cellar/boost/
1.68.0_1
llvm$ cat /usr/local/Cellar/boost/*/include/boost/version.hpp | grep -P '^ *#define +BOOST_VERSION +'
#define BOOST_VERSION 106800
llvm$ ccache --version
-bash: ccache: command not found
llvm$ sccache --version
-bash: sccache: command not found
```
...using these steps:
```
llvm$ mkdir build
llvm$ cd build
build$ cmake ..
build$ make -j 10
```
Everything worked.