### PR TITLE
Bump clang to support `eosio::read_only` attribute

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,6 @@
 [submodule "tools/clang"]
 	path = tools/clang
 	url = https://github.com/eosio/clang.git
-	branch = qy-read-only-action
 [submodule "tools/lld"]
 	path = tools/lld
 	url = https://github.com/eosio/lld.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "tools/clang"]
 	path = tools/clang
 	url = https://github.com/eosio/clang.git
+	branch = qy-read-only-action
 [submodule "tools/lld"]
 	path = tools/lld
 	url = https://github.com/eosio/lld.git


### PR DESCRIPTION
This PR bumps clang to the head of `eosio` branch, which has merged "eosio::read_only" attribute.